### PR TITLE
Allow uncaught exception to be reported to nunit

### DIFF
--- a/RetryOnException/RetryOnException.cs
+++ b/RetryOnException/RetryOnException.cs
@@ -49,22 +49,23 @@ namespace RetryOnException
                 {
                     resultState = innerCommand.Execute(context).ResultState;
                 }
-                catch (Exception ex)
+                catch (Exception thrownException)
                 {
-                    if (ex is NUnitException)
+                    if (thrownException is NUnitException)
                     {
-                        ex = ex.InnerException;
+                        thrownException = thrownException.InnerException;
                     }
-                    caughtType = ex.GetType();
-                    exception = ex;
+                    caughtType = thrownException.GetType();
+                    exception = thrownException;
+
+                    if (_listOfExceptions.Any(ex => ex == caughtType || caughtType == typeof(AssertionException)))
+                    {
+                        return ReturnTestResult(context, caughtType, exception);
+                    }
+
+                    throw;
                 }
 
-                if (_listOfExceptions.Any(ex => ex == caughtType || caughtType == typeof(AssertionException)))
-                {
-                    return ReturnTestResult(context, caughtType, exception);
-                }
-
-                context.CurrentResult.SetResult(resultState);
                 return context.CurrentResult;
             }
 


### PR DESCRIPTION
Hi Steve,

We've noticed that exceptions that aren't included in the list aren't being reported properly by NUnit, for example, given the following test:

```
        int count = 0;

        [Test]
        [Retry(2)]
        [RetryOnException(ListOfExceptions = new[] { typeof(NullReferenceException) })]
        public void RetryTestWithNonCaughtException()
        {
            if (count < 1)
            {
                count++;
                throw new InvalidOperationException("Test Exception");
            }

            Assert.False(false);
        }
```

Nunit is currently reporting the following information:

![actual](https://cloud.githubusercontent.com/assets/1361010/19109747/aac79bf4-8aee-11e6-9a55-a4efd1d4f7cb.PNG)

When normally you would get:

![expected](https://cloud.githubusercontent.com/assets/1361010/19109712/7557a14e-8aee-11e6-852d-0c8e6f5df045.PNG)

Change in this PR moves the exception handling around so we can re throw the exception if its not in the list of exceptions we care about - what do you think?

I tried running the tests to check this, but they were all failing prior to my changes :(

Thanks,
Rhys
